### PR TITLE
fixed unexported function breaking selenium_youtube

### DIFF
--- a/kstopit/__init__.py
+++ b/kstopit/__init__.py
@@ -1,4 +1,4 @@
-from .kstopit import signal_timeoutable, threading_timeoutable
+from .kstopit import signal_timeoutable, threading_timeoutable, timeoutable
 from .timeout_type import TimeoutType
 
 from stopit import TimeoutException


### PR DESCRIPTION
Exporting the `timeoutable` function (said to be public, but not exported) that was breaking [selenium_youtube](https://github.com/kkristof200/selenium_youtube) version `2.0.29` because it was trying to import it.